### PR TITLE
[Op] the 'GroupEmbeddingVarLookup' optimization.

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -5386,7 +5386,6 @@ tf_cuda_cc_test(
     name = "group_embedding_ops_test",
     size = "small",
     srcs = ["group_lookup_ops_test.cc"],
-    tags = tf_cuda_tests_tags(),
     extra_copts = ["-fexceptions", "-g"],
     deps = [
         ":group_embedding_ops",


### PR DESCRIPTION
- using "unique_ali_op.cc" op implementation instead of the original (**20% boost at stage unique**);
- using SIMD optimization(**50% boost at stage combiner**);
![image](https://user-images.githubusercontent.com/19548774/232796150-82151405-a97a-4332-a91e-b0e58bce9ab4.png)
![image](https://user-images.githubusercontent.com/19548774/232797894-d8ad896b-db99-4505-825e-2903363fda2c.png)
